### PR TITLE
fix: dynamic `editUrl` path for documentation subfolder structure

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -40,7 +40,7 @@ const config = {
       'classic',
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
-           docs: {
+          docs: {
           sidebarPath: './sidebars.js',
           // Dynamic editUrl construction
           editUrl: ({ versionDocsDirPath, docPath }) =>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -41,10 +41,11 @@ const config = {
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
         docs: {
-          sidebarPath: './sidebars.js',
-          // Please change this to your repo.
-          editUrl:
-          'https://github.com/open-sauced/intro',
+          sidebarPath: require.resolve('./sidebars.js'),
+          path: './docs',
+          // Dynamic editUrl construction
+          editUrl: ({ versionDocsDirPath, docPath }) =>
+            `https://github.com/open-sauced/intro/edit/main/${versionDocsDirPath}/${docPath}`,
           routeBasePath: '/',
         },
         theme: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -40,9 +40,8 @@ const config = {
       'classic',
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
-        docs: {
-          sidebarPath: require.resolve('./sidebars.js'),
-          path: './docs',
+           docs: {
+          sidebarPath: './sidebars.js',
           // Dynamic editUrl construction
           editUrl: ({ versionDocsDirPath, docPath }) =>
             `https://github.com/open-sauced/intro/edit/main/${versionDocsDirPath}/${docPath}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "@open-sauced/intro.opensauced.pizza",
+    "name": "courses",
     "version": "0.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "@open-sauced/intro.opensauced.pizza",
+            "name": "courses",
             "version": "0.0.0",
             "dependencies": {
                 "@docusaurus/core": "3.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "courses",
+    "name": "@open-sauced/intro.opensauced.pizza",
     "version": "0.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "courses",
+            "name": "@open-sauced/intro.opensauced.pizza",
             "version": "0.0.0",
             "dependencies": {
                 "@docusaurus/core": "3.4.0",


### PR DESCRIPTION
### Description:
This pull request addresses an issue with the `editUrl` configuration in the `docusaurus.config.js` file, where the `editUrl` was incorrectly concatenating the paths for editing the documentation. The issue was observed when the documentation structure was split into multiple subfolders, but the correct path was not reflected in the edit links.

#### Problem:
When attempting to edit documentation from the site, the generated edit URL was appending paths incorrectly. For example, it was redirecting users to:
```
https://github.com/open-sauced/intro/blob/main/docs/intro-to-oss/README.md/docs/intro-to-oss/README.md
```
This resulted in a broken link because of the duplicate path segments.

#### Solution:
1. **Dynamic Path Handling**: Updated the `editUrl` on line 47 of the `docusaurus.config.js` file to handle the subfolder structure dynamically. The `editUrl` now accurately reflects the path by properly concatenating the correct segments of the URL.
   
2. **Folder Structure**: The course documentation was split into two subfolders, which wasn't properly handled in the `editUrl` path. The issue has now been resolved by making the `editUrl` match the actual structure of the docs subfolder.

### Changes Made:
- Modified the `editUrl` on line 47 of the `docusaurus.config.js` to dynamically handle the subfolder structure.
- Ensured that the URL correctly redirects to the `main` branch of the GitHub repository for the documentation:
   ```
   https://github.com/open-sauced/intro/blob/main/docs/intro-to-oss/README.md
   ```

### Verification:
- Verified that the changes work locally by testing the documentation edit links in the Docusaurus site. The edit links now correctly redirect to the respective documentation files in the GitHub repository.
  
### Affected Files:
- `docusaurus.config.js`: Corrected the `editUrl` configuration to prevent path duplication and broken links.

### Related Issues:
Close #241 
---