### PR TITLE
docs: add descriptive alt text to all images for accessibility

### DIFF
--- a/docs/becoming-a-maintainer/getting-practical.md
+++ b/docs/becoming-a-maintainer/getting-practical.md
@@ -33,7 +33,7 @@ We will walk through the steps to set up your project in GitHub. Although it's n
 - Initialize the repository with a README file and add a license.
 - Click the "Create repository" button.
 
-![setting up a repo](../_assets/gifs/set-up-repo.gif)
+![Animated walkthrough of creating a new GitHub repository, entering a name and description, and initializing with a README](../_assets/gifs/set-up-repo.gif)
 
 If you're using our starter idea, you could use the following:
 
@@ -332,7 +332,7 @@ body:
 
 - In your repository, click the "Issues" tab and then the "New issue" button.
 
-  ![create issue](../_assets/images/create-issue.png)
+  ![GitHub Issues tab showing the green New Issue button used to create a new issue in a repository](../_assets/images/create-issue.png)
 
 - Select the type of issue you want to create. In this example, we'll select Feature Request.
 - Write your issue. If you're following along the example, we'll write a feature request for a new resource:
@@ -347,7 +347,7 @@ body:
 
 - Once you've completed the issues, click "Submit new issue."
 
-  ![feature-form.png](../_assets/images/feature-form.png)
+  ![Completed feature request issue form on GitHub with type, current behavior, suggested solution, and code of conduct sections filled in](../_assets/images/feature-form.png)
 
 ### Promoting Your Project
 

--- a/docs/becoming-a-maintainer/how-to-setup-your-project.md
+++ b/docs/becoming-a-maintainer/how-to-setup-your-project.md
@@ -165,7 +165,7 @@ To create issue templates using GitHub's template builder, you will need to:
 
 You can follow the [detailed guide](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-templates) in the GitHub documentation to create one.
 
-![Issue template GIF](../_assets/gifs/issues-template.gif)
+![Animated walkthrough of creating an issue template using GitHub's template builder in repository settings](../_assets/gifs/issues-template.gif)
 
 #### 2. Using YAML Files
 
@@ -197,7 +197,7 @@ Here are a few things to include in your pull request template:
 
 Here is an example of a [pull request template](https://raw.githubusercontent.com/open-sauced/.github/main/.github/PULL_REQUEST_TEMPLATE.md) used by OpenSauced. Please read the [GitHub documentation](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) to learn more about creating pull request templates.
 
-![PR template example](../_assets/images/pr-template.png)
+![Example pull request template on GitHub showing sections for description, related tickets, screenshots, and QA steps](../_assets/images/pr-template.png)
 
 ## Projects on GitHub
 
@@ -220,6 +220,6 @@ Projects are private by default. You can make them private to core maintainers o
 
 Please read the [GitHub documentation](https://docs.github.com/en/issues/planning-and-tracking-with-projects/managing-items-in-your-project/adding-items-to-your-project) to learn more about adding items to your project.
 
-![GitHub Project Boards GIF](../_assets/gifs/create-github-project.gif)
+![Animated walkthrough of creating a new GitHub Project board, selecting a template, and naming the project](../_assets/gifs/create-github-project.gif)
 
 Learning how to start an open source project involves understanding the importance of clear goals, community, comprehensive documentation, and ensuring quality contributions get merged into your project. The [next chapter](issues-and-pull-requests.md) will discuss handling open issues and pull requests.

--- a/docs/becoming-a-maintainer/issues-and-pull-requests.md
+++ b/docs/becoming-a-maintainer/issues-and-pull-requests.md
@@ -105,7 +105,7 @@ If the author does not address the issue or respond to your initial comment, rep
 
 If multiple contributors fail the same set of tests, the tests may be flaky or broken and need your attention. In those situations, you want to clarify to the contributor that the failing test is not their fault and will be resolved.
 
-![Failed automated tests](../_assets/images/failed-automated-tests.png)
+![GitHub pull request showing failed automated test checks with red X marks indicating test failures](../_assets/images/failed-automated-tests.png)
 
 ### Spam Pull Requests
 

--- a/docs/becoming-a-maintainer/maintainer-powerups.md
+++ b/docs/becoming-a-maintainer/maintainer-powerups.md
@@ -15,7 +15,7 @@ Let's say your project receives more new issues and pull requests daily. You wan
 
 Setting up actions to automate these tasks will save you time responding to contributions individually. You can decide which actions to include in each repository.
 
-![Create GitHub Action](../_assets/images/gh-actions.png)
+![GitHub Actions tab showing the workflow setup page with options to choose or create a new workflow](../_assets/images/gh-actions.png)
 
 ### Types of Actions
 
@@ -108,7 +108,7 @@ Sometimes, you repeatedly write the same reply to issues or pull requests. Clear
 
 Read the GitHub documentation for complete instructions about how to [create saved replies](https://docs.github.com/en/get-started/writing-on-github/working-with-saved-replies/creating-a-saved-reply).
 
-![Saved replies gif](../_assets/gifs/saved-replies.gif)
+![Animated walkthrough of creating and using a saved reply on GitHub to respond to issues and pull requests](../_assets/gifs/saved-replies.gif)
 
 ## Code Owners
 

--- a/docs/becoming-a-maintainer/metrics-and-analytics.md
+++ b/docs/becoming-a-maintainer/metrics-and-analytics.md
@@ -71,7 +71,7 @@ To create a Workspace:
 3. Add your project's repository.
 4. Click "Create Workspace" to create your Workspace.
 
-![Workspaces](../_assets/images/workspace.png)
+![OpenSauced Workspace dashboard showing repository metrics including pull requests, issues, and engagement statistics](../_assets/images/workspace.png)
 
 Within the Repositories dashboard, you can view the following metrics, which are shown over a period of thirty days by default:
 
@@ -107,7 +107,7 @@ To learn and understand more about the data provided, see [Understanding Reposit
 
 :::
 
-![repositories dashboard](../_assets/images/repos-insights.png)
+![OpenSauced Repository Insights dashboard displaying repository activity levels, PR overview, and contributor statistics](../_assets/images/repos-insights.png)
 
 ##### Contributors Dashboard
 
@@ -121,7 +121,7 @@ The Activity dashboard shows a graph of the last time each contributor created t
 
 You can use the information in this dashboard to help you learn about their engagement and general interests. It will be helpful if you want to collaborate with them or consider recruiting a maintainer for your project.
 
-![activity graph](../_assets/images/activity-repos-insights.png)
+![OpenSauced Activity dashboard showing a scatter plot of contributors with their latest PR dates and lines of code touched](../_assets/images/activity-repos-insights.png)
 
 You can create a Contributor Insight Page to track your contributors and ensure you're growing a healthy open source community.
 
@@ -146,12 +146,12 @@ To create a new Contributor Insight Page:
 1. Click the "+" next to "Insights" in the sidebar.
 2. Click "New Contributor Insight." You will be redirected to a page where you can create your new Contributor Insight Page.
 
-   ![New Contributor Insight Page](../_assets/images/contrib-insight-new.png)
+   ![OpenSauced form for creating a new Contributor Insight Page with fields for name and contributor search](../_assets/images/contrib-insight-new.png)
 
 3. Give your page a name.
 4. Add contributors to your page by searching for their GitHub username, syncing your GitHub Team, or importing your GitHub Following.
 
-   ![team sync gif](../_assets/gifs/team-sync.gif)
+   ![Animated walkthrough of syncing a GitHub team to add contributors to an OpenSauced Contributor Insight Page](../_assets/gifs/team-sync.gif)
 
 #### Using Your Contributor Insight Page
 
@@ -169,7 +169,7 @@ The Activity dashboard gives you a graph view with more detailed information on 
 
 You can filter your Contributor Insight Page by All Contributors, Active Contributors, New Contributors, and Alumni Contributors.
 
-![list graph](../_assets/images/list-graph.png)
+![OpenSauced Contributor Insight Activity dashboard showing a graph of contributor activity with filtering options for active, new, and alumni contributors](../_assets/images/list-graph.png)
 
 ##### Staying Informed About Contributor Activity
 

--- a/docs/becoming-a-maintainer/your-team.md
+++ b/docs/becoming-a-maintainer/your-team.md
@@ -75,7 +75,7 @@ To access your team's permissions, navigate to your team's page on GitHub and cl
 
 Here's what it will look like in GitHub:
 
-![team permissions](../_assets/images/org-permissions.png)
+![GitHub organization settings page showing repository permission levels including Read, Triage, Write, Maintain, and Admin options](../_assets/images/org-permissions.png)
 
 ### Additional Permissions to Consider
 
@@ -96,7 +96,7 @@ Here's what it will look like in GitHub:
 
 You can see some of the options here:
 
-![Team permissions GIF](../_assets/gifs/org-permissions.gif)
+![Animated walkthrough of navigating GitHub organization settings to configure team repository permissions](../_assets/gifs/org-permissions.gif)
 
 ## Expanding the Horizons: Enlisting Additional Maintainers
 
@@ -119,11 +119,11 @@ There are two ways to add repositories to your Repository Insight Page:
 1. **Sync GitHub organization**. Syncing your GitHub organization is a good idea if you want a unified view of your project activities and the list of contributors to your project.
 2. **Add individual repositories**. Adding individual repositories is a good idea if you want to look at similar repositories to recruit team members.
 
-![Sync team GIF](../_assets/gifs/team-sync-insights.gif)
+![Animated walkthrough of syncing a GitHub organization and adding repositories to an OpenSauced Repository Insight Page](../_assets/gifs/team-sync-insights.gif)
 
 From there, you can create a list of contributors you're interested in learning more about or connecting with by selecting them from the Contributors dashboard and creating a new Contributor Insight Page.
 
-![Contributor insights list](../_assets/images/contributors-insights.png)
+![OpenSauced Contributors dashboard showing a list of contributors with their activity levels and contribution details](../_assets/images/contributors-insights.png)
 
 ## Adding Team Members
 
@@ -148,7 +148,7 @@ One way to onboard your new team members is to have clear guidelines and include
 
 As your team grows, it's important to keep track of your team's participation and contributions. Depending on the number of people on your team, consider creating a [Contributor Insight Page](https://opensauced.pizza/docs/features/contributor-insights/) to keep track of your team's contributions. This will allow you to see who is contributing to your project and how often, and it will help you identify when it's time to remove someone from your team.
 
-![Team sync GIF](../_assets/gifs/team-sync.gif)
+![Animated walkthrough of syncing a GitHub team to an OpenSauced Contributor Insight Page to track team contributions](../_assets/gifs/team-sync.gif)
 
 ## Saying Farewell: Handling Team Departures
 

--- a/docs/intro-to-oss/how-to-contribute-to-open-source.md
+++ b/docs/intro-to-oss/how-to-contribute-to-open-source.md
@@ -51,7 +51,7 @@ OpenSauced is a powerful tool for finding open source projects to contribute to.
 
 1. **Sign up for an account**: Visit https://www.opensauced.pizza/ and sign up for an account using your GitHub credentials.
 
-   ![OpenSauced signup](../_assets/images/opensauced-signup.png)
+   ![OpenSauced signup page showing the option to sign up with GitHub credentials](../_assets/images/opensauced-signup.png)
 
    During the sign up process, you'll be asked to pick some interests and set your timezone. This will help OpenSauced recommend projects that align with your interests and schedule.
 
@@ -59,7 +59,7 @@ OpenSauced is a powerful tool for finding open source projects to contribute to.
 
 3. **Search for projects**: In the Explore dashboard, you can see a list of repositories and their relevant activity levels and engagement levels that are currently trending. You can also search for projects by typing in the search bar. You can search for projects by name, description, or topic and use this tool to find something that resonates with you.
 
-   ![Explore dashboard](../_assets/images/opensauced-explore.png)
+   ![OpenSauced Explore dashboard showing a list of trending repositories with activity levels and engagement metrics](../_assets/images/opensauced-explore.png)
 
 4. **Save projects to your Insights pages**: When you find projects you're interested in, you can add them to "Insights" pages that give you more details about the activity over the projects. Or, if you'd rather just dive in and contribute, you can skip to the next step.
 
@@ -131,7 +131,7 @@ If the contributing guidelines do not state how to claim an issue, you can ask t
 
 You can leave a comment on the issue, like, "Can I please be assigned to this issue?" When the maintainer has assigned you, you'll notice that your username is now under the "Assignees" section.
 
-![Issue assignees section on GitHub](../_assets/images/issue-assign.png)
+![GitHub issue sidebar showing the Assignees section with a contributor assigned to the issue](../_assets/images/issue-assign.png)
 
 ## Contribution Workflow
 
@@ -219,7 +219,7 @@ It can be challenging to read and fill in a pull request template. Here is some 
 
    Here is an example of a pull request template at OpenSauced in preview mode:
 
-   ![PR template in preview mode](../_assets/images/pr-template-preview.png)
+   ![GitHub pull request template in preview mode showing rendered sections for description, related tickets, screenshots, and QA steps](../_assets/images/pr-template-preview.png)
 
 2. **Headings**
 
@@ -348,7 +348,7 @@ Every project is unique. Each has its own pull request template structure and re
 
   You can find the issue number right after the title, as shown below.
 
-  ![issue number](../_assets/images/issue-number.png)
+  ![GitHub issue page highlighting the issue number displayed next to the issue title](../_assets/images/issue-number.png)
 
   :::info
 
@@ -398,7 +398,7 @@ You'll need to have these tools downloaded and installed on your local machine:
    - Add a title, e.g., `Feature: Add @GITHUB-USERNAME as a contributor`. <br/> Change "@GITHUB-USERNAME" to your GitHub username.
    - Complete the form. Read the instructions under each input label and fill in the textareas using the example shown in the screenshot below with the red line.
 
-     ![guestbook issue form](../_assets/images/guestbook-issue-form.png)
+     ![OpenSauced guestbook issue form with fields for contributor name, GitHub username, and contribution type](../_assets/images/guestbook-issue-form.png)
 
    - Click the "Submit new issue" button.
 
@@ -410,12 +410,12 @@ You'll need to have these tools downloaded and installed on your local machine:
 
    Follow the instructions to add yourself to the guestbook. After you finish and click enter, you must click enter again to confirm your choices.
 
-   ![Adding contributor with CLI on a terminal](../_assets/gifs/cli-tool.gif)
+   ![Animated terminal session showing the all-contributors CLI tool prompting for contributor username and contribution type](../_assets/gifs/cli-tool.gif)
 
 7. Run `npm run contributors:generate` in your terminal to generate the guestbook on the README.
 8. Copy and paste the Markdown of the README in [Markdown Live Preview](https://markdownlivepreview.com/) and take a screenshot of your profile being generated as the example below. You will need this later when creating a pull request.
 
-   ![Profile generated on README](../_assets/images/profile-generated.png)
+   ![Markdown preview of the README showing a newly generated contributor profile with avatar and contribution badges](../_assets/images/profile-generated.png)
 
    :::tip
 
@@ -449,7 +449,7 @@ You'll need to have these tools downloaded and installed on your local machine:
 
 Here's what a completed Pull Request Template for the guestbook looks like. Make sure yours looks like this, updated with your unique information.
 
-![Completed Pull Request Template](../_assets/images/completed-pr-template.png)
+![Completed pull request template on GitHub with all sections filled in, including description, related issue, and screenshot](../_assets/images/completed-pr-template.png)
 
 Congratulations on your first contribution! 🎉
 

--- a/docs/intro-to-oss/tools-to-be-successful.md
+++ b/docs/intro-to-oss/tools-to-be-successful.md
@@ -64,7 +64,7 @@ To practice using GitHub, we're going to walk through creating a repository, clo
 
    Choose yourself as the owner of the repository, and enter a name for your repository. For this example, we'll use `practice-repository`.
 
-   ![Create new repository on GitHub](../_assets/images/new-repo.png)
+   ![GitHub new repository creation form showing fields for owner, repository name, visibility options, and initialization settings](../_assets/images/new-repo.png)
 
    Choose whether you want it to be public or private. You can also choose to initialize the repository with a README file, a `.gitignore` file, and/or a license.
 


### PR DESCRIPTION
## Summary
- Replaces generic or non-descriptive alt text across all 30 images and GIFs in the `docs/` directory with meaningful, descriptive alternatives
- Alt text now conveys the content and purpose of each visual element (screenshots, GIFs, diagrams) following accessibility best practices
- Covers all files in both `docs/intro-to-oss/` and `docs/becoming-a-maintainer/` sections

## Changes Made
**Files updated (8 total):**
- `docs/becoming-a-maintainer/your-team.md` - 5 images
- `docs/becoming-a-maintainer/maintainer-powerups.md` - 2 images
- `docs/becoming-a-maintainer/how-to-setup-your-project.md` - 3 images
- `docs/becoming-a-maintainer/metrics-and-analytics.md` - 6 images
- `docs/becoming-a-maintainer/getting-practical.md` - 3 images
- `docs/becoming-a-maintainer/issues-and-pull-requests.md` - 1 image
- `docs/intro-to-oss/how-to-contribute-to-open-source.md` - 9 images
- `docs/intro-to-oss/tools-to-be-successful.md` - 1 image

## Alt Text Guidelines Applied
- Screenshots describe what is shown in the interface, not just "screenshot"
- GIFs describe the action/workflow being demonstrated, prefixed with "Animated walkthrough of..."
- Alt text is concise but descriptive enough for screen reader users to understand the content
- No images were left with empty or generic alt text

Closes #266

Co-authored-by: Egger <egger@horny-toad.com>