### PR TITLE
docs: standardize Markdown formatting across documentation

### DIFF
--- a/contributing/CONTRIBUTING.md
+++ b/contributing/CONTRIBUTING.md
@@ -153,7 +153,7 @@ Follow these steps to add a new chapter to our course:
 
    Here is an example:
 
-   ```yml
+   ```yaml
    ---
    id: what-is-open-source
    title: "What is Open Source?"

--- a/docs/becoming-a-maintainer/getting-practical.md
+++ b/docs/becoming-a-maintainer/getting-practical.md
@@ -156,7 +156,7 @@ It's essential to have a code of conduct to ensure that everyone feels welcome a
    - [ ] Add a link to the code of conduct in your README and CONTRIBUTING files.
 
    :::note
-   
+
    Make sure you attribute the code of conduct to the original author.
 
    :::
@@ -187,7 +187,7 @@ Below are the steps to create the template. After the steps, we'll share with yo
 
 Here's what we use at OpenSauced:
 
-```yml
+```yaml
 name: 🐛 Bug report
 description: Create a bug report to help us improve Open Sauced 🍕
 title: "Bug: "
@@ -266,7 +266,7 @@ Now, let's follow the same process and make a feature request template.
 
 Here's what we use at OpenSauced:
 
-```yml
+```yaml
 name: 🚀 Feature request
 description: Suggest an idea for this project 💡
 title: "Feature: "

--- a/docs/becoming-a-maintainer/how-to-setup-your-project.md
+++ b/docs/becoming-a-maintainer/how-to-setup-your-project.md
@@ -175,7 +175,7 @@ You can also create custom issue templates using YAML frontmatter:
 - Add a folder called `ISSUE_TEMPLATE` inside the `.github` folder.
 
   :::note
-  
+
   The name of this folder should be in all caps, or else it will not work on GitHub.
 
   :::

--- a/docs/becoming-a-maintainer/your-team.md
+++ b/docs/becoming-a-maintainer/your-team.md
@@ -68,8 +68,8 @@ Each team should have a specific set of permissions that allow them to do what t
 - **Read**: Allow members to view code, issues, and pull requests. <br/>_Suitable for stakeholders, external collaborators, or those needing general visibility._
 - **Triage**: Grant permission to manage issues and pull requests (assign, label, comment, close) but not directly modify code. <br/>_Ideal for triage teams and community managers._
 - **Write**: Allow members to push code, create branches, and open pull requests. <br/>_Necessary for developers and maintainers who are actively contributing to the codebase._
-- **Maintain**: Grant broader management permissions, including deleting branches, editing protected files, and managing releases. <br/> _Suitable for core maintainers responsible for project health._
-- **Admin**: Provide full control over the repository, including sensitive actions like deleting or changing its visibility. <br/>_Reserved for trusted individuals or those with specific administrative needs._<br/>
+- **Maintain**: Grant broader management permissions, including deleting branches, editing protected files, and managing releases. <br/>_Suitable for core maintainers responsible for project health._
+- **Admin**: Provide full control over the repository, including sensitive actions like deleting or changing its visibility. <br/>_Reserved for trusted individuals or those with specific administrative needs._
 
 To access your team's permissions, navigate to your team's page on GitHub and click the "Settings" tab. From there, you can update your team's permissions in the "Member privileges" section.
 

--- a/docs/intro-to-oss/conclusion.md
+++ b/docs/intro-to-oss/conclusion.md
@@ -5,7 +5,6 @@ sidebar_label: "Conclusion"
 keywords: ["conclusion", "steps to continue open source contributions", "Open Source", "Open Source Community"]
 ---
 
-
 As we wrap up this course on getting started with open source, let's recap the key takeaways and look at what's next in your open source journey.
 
 ## Takeaways
@@ -28,7 +27,6 @@ By understanding these concepts and applying the strategies we've discussed, you
 
 ## What's Next?
 
-
 With the knowledge and tools you've gained from this course, you're ready to dive into the world of open source and start making meaningful contributions. Here are some next steps to help you continue your open source journey:
 
 1. **Identify your interests and goals**: Before you start contributing to open source projects, take some time to think about your interests, passions, and goals. This will help you find projects that align with your values and objectives.
@@ -44,6 +42,5 @@ With the knowledge and tools you've gained from this course, you're ready to div
 6. **Share your experiences**: Document your open source journey by writing blog posts, creating tutorials, or giving presentations. This will not only help others learn from your experiences but also establish you as a thought leader in the open source community.
 
 7. **Continue learning**: Open source is a dynamic and ever-evolving field. Stay current with the latest tools, techniques, and best practices by attending workshops, taking online courses, and reading articles and books on open source development. We've included an [additional resources section](additional-resources.md) for more information.
-
 
 In conclusion, embarking on an open source journey is a rewarding and enriching experience that can help you develop new skills, connect with like-minded individuals, and make a lasting impact on the projects you work on. With the knowledge and tools you've gained from this course, you're well-prepared to take on the exciting challenges and opportunities that await you in the open source world. So go forth and start contributing—the open source community eagerly awaits your participation!


### PR DESCRIPTION
## Summary
- Fixes formatting inconsistencies across all documentation files in the `docs/` directory and `contributing/CONTRIBUTING.md`
- Standardizes code block language identifiers, removes trailing whitespace, fixes extra blank lines, and normalizes HTML tag spacing

## Changes Made

### Code block language tags
- Standardized `yml` to `yaml` in `docs/becoming-a-maintainer/getting-practical.md` (2 occurrences) and `contributing/CONTRIBUTING.md` (1 occurrence) for consistency with the [YAML specification](https://yaml.org/)

### Trailing whitespace
- Removed trailing whitespace inside `:::note` admonition blocks in:
  - `docs/becoming-a-maintainer/getting-practical.md` (line 159)
  - `docs/becoming-a-maintainer/how-to-setup-your-project.md` (line 178)

### Extra blank lines
- Removed extra blank lines in `docs/intro-to-oss/conclusion.md`:
  - Between frontmatter and first paragraph
  - Between "What's Next?" heading and content
  - Between last list item and closing paragraph

### HTML tag formatting
- Normalized `<br/>` spacing in `docs/becoming-a-maintainer/your-team.md`:
  - Removed extra space in `<br/> _Suitable` to match pattern `<br/>_Text` used elsewhere
  - Removed trailing `<br/>` at end of Admin permission list item

## Style Guidelines Reference
The project already has a comprehensive Markdown style guide in `contributing/CONTRIBUTING.md` under "Using Markdown for This Project." All changes in this PR align with those existing guidelines.

Closes #271

Co-authored-by: Egger <egger@horny-toad.com>