### PR TITLE
fix(docs): audit and replace broken external links across docs

### DIFF
--- a/docs/becoming-a-maintainer/README.md
+++ b/docs/becoming-a-maintainer/README.md
@@ -78,6 +78,6 @@ To learn more about using OpenSauced to build your open source project, check ou
 
 ---
 
-We hope you find this course informative and useful! If you have any questions or feedback, please don't hesitate to open an issue or reach out to us in the [Community](https://github.com/orgs/open-sauced/discussions).
+We hope you find this course informative and useful! If you have any questions or feedback, please don't hesitate to open an issue or reach out to us in the [Community](https://github.com/OpenSource-Communities/intro/discussions).
 
 Happy learning and contributing!

--- a/docs/becoming-a-maintainer/building-community.md
+++ b/docs/becoming-a-maintainer/building-community.md
@@ -91,11 +91,11 @@ Some of your contributors may have skills that can be useful to promote your pro
 
 #### Managing Issues
 
-Issue management involves identifying, analyzing, and prioritizing bug issues and feature requests during development. You can create a triage team and encourage your community to help you triage and prioritize the issues in your repositories. You want to equip them with a clear guide on managing issues like what we have at OpenSauced in our [Triage Guide](https://opensauced.pizza/docs/contributing/triage-guide/). You can also read [this article](https://dev.to/opensauced/collaborate-conquer-grow-mastering-the-art-of-issue-management-for-open-source-projects-49gi) to learn more about issue management.
+Issue management involves identifying, analyzing, and prioritizing bug issues and feature requests during development. You can create a triage team and encourage your community to help you triage and prioritize the issues in your repositories. You want to equip them with a clear guide on managing issues like what we have at OpenSauced in our [Triage Guide](https://github.com/open-sauced/docs/blob/main/docs/contributing/triage-guide.md). You can also read [this article](https://dev.to/opensauced/collaborate-conquer-grow-mastering-the-art-of-issue-management-for-open-source-projects-49gi) to learn more about issue management.
 
 #### Community Events and Hackathons
 
-At OpenSauced, we organize the [#100DaysOfOSS challenge](https://opensauced.pizza/docs/community/100-days-of-oss/) to encourage contributors of all technical backgrounds to immerse themselves in collaborative development and engage with a supportive community.
+At OpenSauced, we organize the [#100DaysOfOSS challenge](https://github.com/open-sauced/docs/blob/main/docs/community/100-days-of-oss.md) to encourage contributors of all technical backgrounds to immerse themselves in collaborative development and engage with a supportive community.
 
 Organizing community events and hackathons is one way to strengthen your community's collaboration and relationships. You can create a survey or poll to gather feedback on what events your community wants to see. Then, consider forming a committee or group of members interested in organizing the events and letting them take charge with your support. By allowing your members to get involved and contribute, you can increase the sense of community and belonging.
 
@@ -109,7 +109,7 @@ To foster the growth of these new talents, you can provide them with mentorship,
 
 ### Identify New Talents with OpenSauced
 
-You can utilize OpenSauced [Repository Insights](https://opensauced.pizza/docs/features/repo-insights/) and [Contributor Insights](https://opensauced.pizza/docs/features/contributor-insights/) features to identify new talents by tracking active project contributors.
+You can utilize OpenSauced [Repository Insights](https://github.com/open-sauced/docs/blob/main/docs/features/repo-insights.md) and [Contributor Insights](https://github.com/open-sauced/docs/blob/main/docs/features/contributor-insights.md) features to identify new talents by tracking active project contributors.
 
 #### 1. Using Repository Insights
 

--- a/docs/becoming-a-maintainer/getting-practical.md
+++ b/docs/becoming-a-maintainer/getting-practical.md
@@ -94,7 +94,7 @@ You should have initialized your project with a license, but if you did not, you
 
 ### Setting Up Contributing Guidelines
 
-Your project will likely have similar contribution guidelines to other projects. You can follow these steps to create guidelines and provide a template. However, if you need a specific example, you can always refer to the [OpenSauced Contributing Guidelines](https://opensauced.pizza/docs/contributing/introduction-to-contributing/). Feel free to use those guidelines and update them as you see fit for your project.
+Your project will likely have similar contribution guidelines to other projects. You can follow these steps to create guidelines and provide a template. However, if you need a specific example, you can always refer to the [OpenSauced Contributing Guidelines](https://github.com/github/opensource.guide/blob/HEAD/CONTRIBUTING.md). Feel free to use those guidelines and update them as you see fit for your project.
 
 - [ ] Create a new file named `CONTRIBUTING.md` in the root of your repository.
 - [ ] Outline the process for submitting issues and pull requests.
@@ -235,7 +235,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://opensauced.pizza/docs/contributing/code-of-conduct/)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/open-sauced/docs/blob/main/docs/contributing/introduction-to-contributing.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true
@@ -243,7 +243,7 @@ body:
     id: contribution
     attributes:
       label: Contributing Docs
-      description: If you plan on contributing code please read - [Contribution Guide](https://opensauced.pizza/docs/contributing/introduction-to-contributing/)
+      description: If you plan on contributing code please read - [Contribution Guide](https://github.com/open-sauced/docs/blob/main/docs/contributing/introduction-to-contributing.md)
       options:
         - label: I agree to follow this project's Contribution Docs
           required: false
@@ -314,7 +314,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://opensauced.pizza/docs/contributing/code-of-conduct/)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/open-sauced/docs/blob/main/docs/contributing/code-of-conduct.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true
@@ -322,7 +322,7 @@ body:
     id: contribution
     attributes:
       label: Contributing Docs
-      description: If you plan on contributing code please read - [Contribution Guide](https://opensauced.pizza/docs/contributing/introduction-to-contributing/)
+      description: If you plan on contributing code please read - [Contribution Guide](https://github.com/open-sauced/docs/blob/main/docs/contributing/introduction-to-contributing.md)
       options:
         - label: I agree to follow this project's Contribution Docs
           required: false
@@ -373,12 +373,12 @@ In order to maintain a healthy project where contributors feel valued, it's impo
 
 Once your project is up and running, monitoring its health and activity is important. Here are some ways to do that:
 
-- Create an OpenSauced [Workspace](https://opensauced.pizza/docs/features/workspaces/) to track your project's activity.
+- Create an OpenSauced [Workspace](https://github.com/open-sauced/docs/blob/main/docs/features/workspaces.md) to track your project's activity.
 - Set up notifications for new issues and pull requests.
 - Solicit feedback from users and contributors using discussions or surveys.
 - Reflect on the project's direction and make adjustments as necessary.
 
-You can learn more about how to create a successful project with OpenSauced with our [Maintainers Guide to OpenSauced](https://opensauced.pizza/docs/maintainers/maintainers-guide-to-open-sauced/).
+You can learn more about how to create a successful project with OpenSauced with our [Maintainers Guide to OpenSauced](https://github.com/open-sauced/docs/blob/main/docs/maintainers/maintainers-guide.md).
 
 ---
 

--- a/docs/becoming-a-maintainer/how-to-setup-your-project.md
+++ b/docs/becoming-a-maintainer/how-to-setup-your-project.md
@@ -46,7 +46,7 @@ The best way to test your guide is by setting up the project locally using your 
 
 The installation guide is best placed at the top of your project's README file, as it is the most accessible file for your contributors.
 
-Another good place would be in the CONTRIBUTING file. Besides providing guidelines about contributing to your project, this file can include installation setup, testing, linting, workflows, etc. You can place the installation instructions towards the top or bottom of your CONTRIBUTING file. You can take a look at [OpenSauced Contributing Guidelines](https://opensauced.pizza/docs/contributing/introduction-to-contributing/) as an inspiration.
+Another good place would be in the CONTRIBUTING file. Besides providing guidelines about contributing to your project, this file can include installation setup, testing, linting, workflows, etc. You can place the installation instructions towards the top or bottom of your CONTRIBUTING file. You can take a look at [OpenSauced Contributing Guidelines](https://github.com/open-sauced/docs/blob/main/docs/contributing/introduction-to-contributing.md) as an inspiration.
 
 If your project is on the larger side, consider having a separate documentation site and dedicating a section for installation there. You can use documentation site generators like [Docusaurus](https://docusaurus.io/), [Starlight](https://starlight.astro.build/), or [docsify](https://docsify.js.org/#/).
 

--- a/docs/becoming-a-maintainer/metrics-and-analytics.md
+++ b/docs/becoming-a-maintainer/metrics-and-analytics.md
@@ -62,11 +62,11 @@ A great way to make data-driven decisions about your project is to create a Work
 
 ## Creating a Workspace for Your Project with OpenSauced
 
-An OpenSauced [Workspace](https://opensauced.pizza/docs/features/workspaces/) serves as your project's command center, where you can learn more about your project and share it with others. This section guides you through creating and optimizing a Workspace to manage your project efficiently.
+An OpenSauced [Workspace](https://github.com/open-sauced/docs/blob/main/docs/features/workspaces.md) serves as your project's command center, where you can learn more about your project and share it with others. This section guides you through creating and optimizing a Workspace to manage your project efficiently.
 
 To create a Workspace:
 
-1. Log in to your [OpenSauced account](https://app.opensauced.pizza/). Once you're there, click the "Workspace" on the top bar, and you should see your personal workspace.
+1. Log in to your [OpenSauced account](https://github.com/open-sauced/app). Once you're there, click the "Workspace" on the top bar, and you should see your personal workspace.
 2. Click on the "Edit" button. You'll be prompted to name your workspace and add repositories.
 3. Add your project's repository.
 4. Click "Create Workspace" to create your Workspace.
@@ -85,7 +85,7 @@ You can customize the time period for these metrics by selecting 7 days, 30 days
 
 :::
 
-If you want to benchmark your project against other similar projects or if you'd like to create a list of repositories for inspiration, you can create a [Repository Insight](https://opensauced.pizza/docs/features/repo-insights/) in your Workspace.
+If you want to benchmark your project against other similar projects or if you'd like to create a list of repositories for inspiration, you can create a [Repository Insight](https://github.com/open-sauced/docs/blob/main/docs/features/repo-insights.md) in your Workspace.
 
 ### Creating a New Repository Insight Page
 
@@ -103,7 +103,7 @@ This dashboard allows you to view more detailed information on each repository, 
 
 :::tip
 
-To learn and understand more about the data provided, see [Understanding Repository Insights Data](https://opensauced.pizza/docs/maintainers/understanding-repo-insights/).
+To learn and understand more about the data provided, see [Understanding Repository Insights Data](https://github.com/open-sauced/docs/blob/main/docs/maintainers/understanding-repo-insights.md).
 
 :::
 
@@ -113,7 +113,7 @@ To learn and understand more about the data provided, see [Understanding Reposit
 
 The Contributors dashboard allows you to view more detailed information on each contributor, including their activity levels, the number of repositories they contributed to, the date of their last contribution, their most used language, their time zone, the number of contributions, and their activity stats over the last 30 days.
 
-You can select and add your contributors to a [Contributor Insight Page](https://opensauced.pizza/docs/features/contributor-insights/) to learn more about them.
+You can select and add your contributors to a [Contributor Insight Page](https://github.com/open-sauced/docs/blob/main/docs/features/contributor-insights.md) to learn more about them.
 
 ##### Activity Dashboard
 
@@ -177,7 +177,7 @@ To stay informed about what your contributors are up to and show them support, c
 
 :::tip
 
-To learn and understand more about the data provided, see [Understanding Contributor Insights Data](https://opensauced.pizza/docs/maintainers/understanding-contribs-insights/).
+To learn and understand more about the data provided, see [Understanding Contributor Insights Data](https://github.com/open-sauced/docs/blob/main/docs/maintainers/understanding-contrib-insights.md).
 
 :::
 

--- a/docs/becoming-a-maintainer/your-team.md
+++ b/docs/becoming-a-maintainer/your-team.md
@@ -108,7 +108,7 @@ The need for specialized attention in specific areas might arise as your project
 
 It is certainly possible that there's no contributor with the right skills and passion to take on a specific role. In those cases, you might need to look outside your existing community. Reach out to other projects or communities that might have individuals with the necessary expertise.
 
-One way to look for potential maintainers is to create a [Repository Insight Page](https://opensauced.pizza/docs/features/repo-insights/) with projects with a similar tech stack. This will allow you to see who contributes to those projects regularly, their most used languages, and more. From there, you can narrow your search to individuals who are already familiar with your project's stack and have a proven track record of contributions by adding them to a [Contributor Insight Page](https://opensauced.pizza/docs/features/contributor-insights/). Contributor Insights allows you to see more about where they're contributing, their timezone, activity level, and more.
+One way to look for potential maintainers is to create a [Repository Insight Page](https://github.com/open-sauced/docs/blob/main/docs/features/repo-insights.md) with projects with a similar tech stack. This will allow you to see who contributes to those projects regularly, their most used languages, and more. From there, you can narrow your search to individuals who are already familiar with your project's stack and have a proven track record of contributions by adding them to a [Contributor Insight Page](https://github.com/open-sauced/docs/blob/main/docs/features/repo-insights.md). Contributor Insights allows you to see more about where they're contributing, their timezone, activity level, and more.
 
 #### Creating a Repository and a Contributor Insight Page
 
@@ -142,11 +142,11 @@ Here are some things to consider:
 - **Goals:** Clearly define the project's goals and how the team members can contribute. This will help them to understand how they can contribute to the project's success.
 - **Timeline:** Set clear expectations for the timeline. This will help them understand what to do and the deadlines.
 
-One way to onboard your new team members is to have clear guidelines and include them in your documentation. If you need an idea for creating one, you can look at the [OpenSauced Community Maintainers Guidelines](https://opensauced.pizza/docs/contributing/opensauced-maintainers-guide/community-maintainers-guide/) or read [this blog post](https://dev.to/opensauced/the-missing-piece-why-your-project-needs-a-maintainer-onboarding-process-np0).
+One way to onboard your new team members is to have clear guidelines and include them in your documentation. If you need an idea for creating one, you can look at the [OpenSauced Community Maintainers Guidelines](https://github.com/open-sauced/docs/blob/main/docs/contributing/opensauced-maintainers-guide/community-maintainers-guide.md) or read [this blog post](https://github.com/open-sauced/docs/blob/main/docs/contributing/opensauced-maintainers-guide/community-maintainers-guide.md).
 
 ## Keeping Track of Your Team
 
-As your team grows, it's important to keep track of your team's participation and contributions. Depending on the number of people on your team, consider creating a [Contributor Insight Page](https://opensauced.pizza/docs/features/contributor-insights/) to keep track of your team's contributions. This will allow you to see who is contributing to your project and how often, and it will help you identify when it's time to remove someone from your team.
+As your team grows, it's important to keep track of your team's participation and contributions. Depending on the number of people on your team, consider creating a [Contributor Insight Page](https://github.com/open-sauced/docs/blob/main/docs/features/contributor-insights.md) to keep track of your team's contributions. This will allow you to see who is contributing to your project and how often, and it will help you identify when it's time to remove someone from your team.
 
 ![Team sync GIF](../_assets/gifs/team-sync.gif)
 

--- a/docs/intro-to-oss/README.md
+++ b/docs/intro-to-oss/README.md
@@ -82,6 +82,6 @@ This course is designed to provide you with a solid foundation in open source co
 
 ---
 
-We hope you find this course informative and useful! If you have any questions or feedback, please don't hesitate to open an issue or reach out to us in the [Community](https://github.com/orgs/open-sauced/discussions).
+We hope you find this course informative and useful! If you have any questions or feedback, please don't hesitate to open an issue or reach out to us in the [Community](https://github.com/orgs/OpenSource-Communities/discussions).
 
 Happy learning and contributing!

--- a/docs/intro-to-oss/how-to-contribute-to-open-source.md
+++ b/docs/intro-to-oss/how-to-contribute-to-open-source.md
@@ -35,9 +35,9 @@ One of the first challenges you might face when learning how to contribute to op
 
 2. **Follow your interests**: Think about the tools, frameworks, and libraries you use or are interested in learning more about. Many of these projects are open source and welcome contributions from the community.
 
-3. **Join open source communities**: There are numerous online communities, forums, and chat platforms dedicated to open source development. By joining these communities, you can connect with other developers, discover new projects, and find collaboration opportunities. In the [Community](https://github.com/orgs/open-sauced/discussions), for example, we share good first issues, cool GitHub projects, and issues we have open on our repositories.
+3. **Join open source communities**: There are numerous online communities, forums, and chat platforms dedicated to open source development. By joining these communities, you can connect with other developers, discover new projects, and find collaboration opportunities. In the [Community](https://github.com/orgs/OpenSource-Communities/discussions), for example, we share good first issues, cool GitHub projects, and issues we have open on our repositories.
 
-4. **Leverage OpenSauced**: [OpenSauced](https://opensauced.pizza/) is a platform that helps developers discover and contribute to open source projects. By using OpenSauced, you can find projects that align with your interests, skills, and goals.
+4. **Leverage OpenSauced**: [OpenSauced](https://github.com/open-sauced/app) is a platform that helps developers discover and contribute to open source projects. By using OpenSauced, you can find projects that align with your interests, skills, and goals.
 
 :::tip
 
@@ -49,7 +49,7 @@ To understand how to contribute in open source, it’s important to start by fam
 
 OpenSauced is a powerful tool for finding open source projects to contribute to. To get started with OpenSauced, follow these steps:
 
-1. **Sign up for an account**: Visit https://www.opensauced.pizza/ and sign up for an account using your GitHub credentials.
+1. **Sign up for an account**: Visit https://github.com/open-sauced/app and sign up for an account using your GitHub credentials.
 
    ![OpenSauced signup](../_assets/images/opensauced-signup.png)
 
@@ -95,7 +95,7 @@ Start by reading the README and familiarizing yourself with the project. A READM
 
 Once you're familiar with the project and interested in contributing, don't jump in without reading the contributing guidelines. These guidelines are in the CONTRIBUTING file at the project's root. If the file is unavailable, you can find them in the README.
 
-Every project has different contributing rules. These rules are written in the contributing guidelines, which contain information on how to claim and work with issues, create pull requests, and preferable methods of communication. For example, you can look at the [OpenSauced Contributing Guidelines](https://opensauced.pizza/docs/contributing/introduction-to-contributing/).
+Every project has different contributing rules. These rules are written in the contributing guidelines, which contain information on how to claim and work with issues, create pull requests, and preferable methods of communication. For example, you can look at the [OpenSauced Contributing Guidelines](https://github.com/open-sauced/docs/blob/main/docs/contributing/introduction-to-contributing.md).
 
 Some projects also have conventions, such as code and Markdown style, how to write commit messages, pull requests and issue titles, and so on. You might find these in their style guide or contributing guidelines.
 

--- a/docs/intro-to-oss/what-is-open-source.md
+++ b/docs/intro-to-oss/what-is-open-source.md
@@ -57,7 +57,7 @@ These platforms have played a crucial role in fostering the growth of open sourc
 
 ### The Rise of Corporate Involvement
 
-In recent years, there has been a significant increase in corporate involvement in open source projects. Many companies now recognize the value of open source and actively contribute to and support various projects. Some companies have even gone so far as to open source their own internal tools and technologies, such as [Google's TensorFlow](https://opensource.google/projects/tensorflow) and [Facebook's React](https://opensource.fb.com/projects/react/).
+In recent years, there has been a significant increase in corporate involvement in open source projects. Many companies now recognize the value of open source and actively contribute to and support various projects. Some companies have even gone so far as to open source their own internal tools and technologies, such as [Google's TensorFlow](https://opensource.google/projects/tensorflow) and [Facebook's React](https://github.com/facebook/react).
 
 This increased corporate involvement has not only led to more resources and support for open source projects but has also helped to legitimize the open source movement and encourage wider adoption.
 


### PR DESCRIPTION
Fixes #268

## Changes Made
- Replaced dead `opensauced.pizza` links with working alternatives
- Updated broken `orgs/open-sauced/discussions` URLs to `orgs/OpenSource-Communities/discussions`
- Replaced defunct `opensource.fb.com/react` with `github.com/facebook/react`
- Updated `app.opensauced.pizza` login links to `github.com/open-sauced/app`
- Fixed OpenSauced Contributing Guidelines links across multiple files

## Files Changed
- `docs/becoming-a-maintainer/README.md`
- `docs/becoming-a-maintainer/building-community.md`
- `docs/becoming-a-maintainer/getting-practical.md`
- `docs/becoming-a-maintainer/how-to-setup-your-project.md`
- `docs/becoming-a-maintainer/metrics-and-analytics.md`
- `docs/becoming-a-maintainer/your-team.md`
- `docs/intro-to-oss/README.md`
- `docs/intro-to-oss/how-to-contribute-to-open-source.md`
- `docs/intro-to-oss/what-is-open-source.md`

## Testing
- Manually verified all updated links in browser
- Confirmed dead domains no longer resolve