### PR TITLE
fix grammar in pull request template section

### DIFF
--- a/docs/intro-to-oss/how-to-contribute-to-open-source.md
+++ b/docs/intro-to-oss/how-to-contribute-to-open-source.md
@@ -211,7 +211,7 @@ Most projects provided a pull request template that is shown and needs to be fil
 
 ##### Tips to Fill In a Pull Request Template
 
-It can be challenging to read and fill in a pull request template. Here is some tips on how to fill one:
+It can be challenging to read and fill in a pull request template. Here are some tips on how to fill one out:
 
 1. **Preview Mode**
 


### PR DESCRIPTION
## Description

This PR fixes a grammatical error in the "Tips to Fill In a Pull Request Template" section.

Changed:
"Here is some tips on how to fill one:"

To:
"Here are some tips on how to fill one out:"

This improves grammatical accuracy and makes the sentence more natural and easier for contributors to understand.

## Related Issues

N/A

## Mobile & Desktop Screenshots/Recordings

N/A - Documentation-only change.

## Steps to QA

1. Open the "How to Contribute to Open Source" page.
2. Navigate to the "Tips to Fill In a Pull Request Template" section.
3. Verify the sentence now reads:
   "Here are some tips on how to fill one out:"

## [optional] What GIF best describes this PR or how it makes you feel?

N/A